### PR TITLE
feat: add username validation to prevent 'System' and duplicates

### DIFF
--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -54,11 +54,13 @@ fn main() -> io::Result<()> {
             break;
         }
         let response = String::from_utf8_lossy(&buf[..n]);
-        if response.contains("Username cannot be empty") {
-            eprintln!("Server rejected username");
+        if response.contains("Username cannot be empty") 
+            || response.contains("Username 'System' is reserved")
+            || response.contains("Username is already taken") {
+            eprintln!("Server rejected username: {}", response.trim());
             return Err(io::Error::new(
                 io::ErrorKind::InvalidInput,
-                "Username rejected by server",
+                response.trim(),
             ));
         }
         initial_messages.push(response.to_string());


### PR DESCRIPTION
- Server now rejects 'System' username (case-insensitive)
- Server prevents duplicate usernames (case-insensitive)
- Client properly handles and displays server rejection messages
- Improves security by preventing system message impersonation

closes #1 